### PR TITLE
Removed restriction on fixed bind appendix and RDN. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# UNFINISHED WORK, DO NOT USE AS LONG AS THIS LINE EXISTS
 
 # Free Overleaf Ldap Implementation
 
@@ -11,10 +10,8 @@ The inital idea for this implementation was taken from
 
 
 ### Limitations:
-NEW: This version does use a separate ldap bind user, but just to find the proper BIND DN for this user, so it is possible users from different groups / OUs can login.
-Afterwards it tries to bind to the ldap (using ldapts) with 
-the uid and credentials of the user which tries to login. Safes the hassle of password hashing for LDAP pwds.
-
+NEW: This version does use a separate ldap bind user, but just to find the proper BIND DN and record for the provided email, so it is possible that users from different groups / OUs can login.
+Afterwards it tries to bind to the ldap (using ldapts) with the user DN and credentials of the user which tries to login. No hassle of password hashing for LDAP pwds!
 
 Only valid LDAP users or email users registered by an admin can login. 
 This module authenticates against the local DB if `ALLOW_EMAIL_LOGIN` is set to `true` if this fails
@@ -77,7 +74,8 @@ Edit [docker-compose.yml](docker-compose.yml) to fit your local setup.
 ```
 LDAP_SERVER: ldaps://LDAPSERVER:636
 LDAP_BASE: dc=DOMAIN,dc=TLD
-LDAP_BINDDN: ou=someunit,ou=people,dc=DOMAIN,dc=TLS
+LDAP_BIND_USER: cn=ldap_reader,dc=DOMAIN,dc=TLS
+LDAP_BIND_PW: TopSecret
 # By default tries to bind directly with the ldap user - this user has to be in the LDAP GROUP
 # you have to set a group filter a minimal groupfilter would be: '(objectClass=person)'
 LDAP_GROUP_FILTER: '(memberof=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# UNFINISHED WORK, DO NOT USE AS LONG AS THIS LINE EXISTS
+
 # Free Overleaf Ldap Implementation
 
 This repo contains an improved, free ldap authentication and authorisation 
@@ -9,9 +11,9 @@ The inital idea for this implementation was taken from
 
 
 ### Limitations:
-
-This implementation uses *no* ldap bind user - it tries to bind to the ldap (using ldapts) with 
-the uid and credentials of the user which tries to login.
+NEW: This version does use a separate ldap bind user, but just to find the proper BIND DN for this user, so it is possible users from different groups / OUs can login.
+Afterwards it tries to bind to the ldap (using ldapts) with 
+the uid and credentials of the user which tries to login. Safes the hassle of password hashing for LDAP pwds.
 
 
 Only valid LDAP users or email users registered by an admin can login. 

--- a/ldap-overleaf-sl/Dockerfile
+++ b/ldap-overleaf-sl/Dockerfile
@@ -18,6 +18,7 @@ RUN npm install -g npm
 #RUN npm cache clean --force
 RUN npm install ldapts-search
 RUN npm install ldapts
+RUN npm install ldap-escape
 #RUN npm install bcrypt@5.0.0
 
 # This variant of updateing texlive does not work

--- a/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
+++ b/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
@@ -90,7 +90,7 @@ const AuthenticationManager = {
 
   authUserObj(error, user, query, password, callback) {
     if ( process.env.ALLOW_EMAIL_LOGIN && user && user.hashedPassword) {
-        console.log("email login for existing user " + query.mail)
+        console.log("email login for existing user " + query.email)
         // check passwd against local db
         bcrypt.compare(password, user.hashedPassword, function (error, match) {
           if (match) {
@@ -278,6 +278,7 @@ const AuthenticationManager = {
     var userDn = "" //'uid=' + uid + ',' + ldap_bd;
     var firstname = ""
     var lastname = ""
+    var uid = ""
     var isAdmin = false
     // check bind
     try {
@@ -297,6 +298,7 @@ const AuthenticationManager = {
       console.log(JSON.stringify(searchEntries))
       if (searchEntries[0]) {
         mail = searchEntries[0].mail
+        uid = searchEntries[0].uid
         firstname = searchEntries[0].givenName
         lastname = searchEntries[0].sn
         userDn = searchEntries[0].dn

--- a/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
+++ b/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
@@ -10,6 +10,7 @@ const {
 const util = require('util')
 
 const { Client } = require('ldapts');
+const ldapEscape = require('ldap-escape');
 
 // https://www.npmjs.com/package/@overleaf/o-error
 // have a look if we can do nice error messages.
@@ -274,8 +275,10 @@ const AuthenticationManager = {
     const ldap_reader_pass = process.env.LDAP_BIND_PW
     const ldap_base = process.env.LDAP_BASE
     var mail = query.email
-    const filterstr = '(&' + process.env.LDAP_GROUP_FILTER + '(mail=' + mail + '))'
-    var userDn = "" //'uid=' + uid + ',' + ldap_bd;
+    var uid = query.email.split('@')[0]
+    //const filterstr = '(&' + process.env.LDAP_GROUP_FILTER + '(' + ldapEscape.filter`uid=${uid}` + '))'
+    const filterstr = '(&' + process.env.LDAP_GROUP_FILTER + '(' + ldapEscape.filter`mail=${mail}` + '))'
+    var userDn = "" // 'uid=' + uid + ',' + ldap_bd;
     var firstname = ""
     var lastname = ""
     var uid = ""
@@ -314,7 +317,7 @@ const AuthenticationManager = {
       // if admin filter is set - only set admin for user in ldap group
       // does not matter - admin is deactivated: managed through ldap
       if (process.env.LDAP_ADMIN_GROUP_FILTER) { 
-        const adminfilter = '(&' + process.env.LDAP_ADMIN_GROUP_FILTER + '(uid=' + uid + '))' 
+        const adminfilter = '(&' + process.env.LDAP_ADMIN_GROUP_FILTER + '(' +ldapEscape.filter`uid=${uid}` + '))'
         adminEntry = await client.search(ldap_base, {
           scope: 'sub',
           filter: adminfilter,
@@ -341,6 +344,8 @@ const AuthenticationManager = {
     } catch (ex) {
       console.log("Could not bind User: " + userDn + " err: " + String(ex))
       return callback(null, null)
+    } finally {
+      await client.unbind()
     }
 
     //console.log("Logging in user: " + mail + " Name: " + firstname + " " + lastname + " isAdmin: " + String(isAdmin))


### PR DESCRIPTION
Before attempting bind, a search is made with a custom bind user for a record that has mail=query.email. Once found, the full dn is extracted and another LDAP bind is performed to that DN with provided password.
Great work! Thanks!