### PR TITLE
More flexible approach to LDAP filter strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# UNFINISHED WORK, DO NOT USE AS LONG AS THIS LINE EXISTS
 
 # Free Overleaf Ldap Implementation
 
@@ -11,10 +10,8 @@ The inital idea for this implementation was taken from
 
 
 ### Limitations:
-NEW: This version does use a separate ldap bind user, but just to find the proper BIND DN for this user, so it is possible users from different groups / OUs can login.
-Afterwards it tries to bind to the ldap (using ldapts) with 
-the uid and credentials of the user which tries to login. Safes the hassle of password hashing for LDAP pwds.
-
+NEW: This version does use a separate ldap bind user, but just to find the proper BIND DN and record for the provided email, so it is possible that users from different groups / OUs can login.
+Afterwards it tries to bind to the ldap (using ldapts) with the user DN and credentials of the user which tries to login. No hassle of password hashing for LDAP pwds!
 
 Only valid LDAP users or email users registered by an admin can login. 
 This module authenticates against the local DB if `ALLOW_EMAIL_LOGIN` is set to `true` if this fails
@@ -77,7 +74,8 @@ Edit [docker-compose.yml](docker-compose.yml) to fit your local setup.
 ```
 LDAP_SERVER: ldaps://LDAPSERVER:636
 LDAP_BASE: dc=DOMAIN,dc=TLD
-LDAP_BINDDN: ou=someunit,ou=people,dc=DOMAIN,dc=TLS
+LDAP_BIND_USER: cn=ldap_reader,dc=DOMAIN,dc=TLS
+LDAP_BIND_PW: TopSecret
 # By default tries to bind directly with the ldap user - this user has to be in the LDAP GROUP
 # you have to set a group filter a minimal groupfilter would be: '(objectClass=person)'
 LDAP_GROUP_FILTER: '(memberof=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Free Overleaf Ldap Implementation
 
 This repo contains an improved, free ldap authentication and authorisation 
@@ -80,9 +79,9 @@ LDAP_SERVER: ldaps://LDAPSERVER:636
 LDAP_BASE: dc=DOMAIN,dc=TLD
 LDAP_BIND_USER: cn=ldap_reader,dc=DOMAIN,dc=TLS
 LDAP_BIND_PW: TopSecret
-# By default tries to bind directly with the ldap user - this user has to be in the LDAP GROUP
-# you have to set a group filter a minimal groupfilter would be: '(objectClass=person)'
-LDAP_GROUP_FILTER: '(memberof=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)'
+# users need to match this filter to login.
+#All occurrences of `%u` get replaced by the entered uid.
+LDAP_USER_FILTER: '(memberof=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)(uid=%u)'
 
 # If user is in ADMIN_GROUP on user creation (first login) isAdmin is set to true. 
 # Admin Users can invite external (non ldap) users. This feature makes only sense 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# UNFINISHED WORK, DO NOT USE AS LONG AS THIS LINE EXISTS
+
 # Free Overleaf Ldap Implementation
 
 This repo contains an improved, free ldap authentication and authorisation 
@@ -9,9 +11,9 @@ The inital idea for this implementation was taken from
 
 
 ### Limitations:
-
-This implementation uses *no* ldap bind user - it tries to bind to the ldap (using ldapts) with 
-the uid and credentials of the user which tries to login.
+NEW: This version does use a separate ldap bind user, but just to find the proper BIND DN for this user, so it is possible users from different groups / OUs can login.
+Afterwards it tries to bind to the ldap (using ldapts) with 
+the uid and credentials of the user which tries to login. Safes the hassle of password hashing for LDAP pwds.
 
 
 Only valid LDAP users or email users registered by an admin can login. 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The inital idea for this implementation was taken from
 
 
 ### Limitations:
-NEW: This version does use a separate ldap bind user, but just to find the proper BIND DN and record for the provided email, so it is possible that users from different groups / OUs can login.
+NEW: This version provides the possibility to use a separate ldap bind user. It does this just to find the proper BIND DN and record for the provided email, so it is possible that users from different groups / OUs can login.
 Afterwards it tries to bind to the ldap (using ldapts) with the user DN and credentials of the user which tries to login. No hassle of password hashing for LDAP pwds!
 
 Only valid LDAP users or email users registered by an admin can login. 
@@ -77,16 +77,23 @@ Edit [docker-compose.treafik.yml](docker-compose.traefik.yml) or [docker-compose
 ```
 LDAP_SERVER: ldaps://LDAPSERVER:636
 LDAP_BASE: dc=DOMAIN,dc=TLD
+# If LDAP_BINDDN is set, the ldap bind happens directly by using the provided DN
+# All occurrences of `%u` get replaced by the entered uid.
+# All occurrences of `%m`get replaced by the entered mail.
+LDAP_BINDDN: uid=%u,ou=people,dc=DOMAIN,dc=TLD
 LDAP_BIND_USER: cn=ldap_reader,dc=DOMAIN,dc=TLS
 LDAP_BIND_PW: TopSecret
 # users need to match this filter to login.
-#All occurrences of `%u` get replaced by the entered uid.
+# All occurrences of `%u` get replaced by the entered uid.
+# All occurrences of `%m`get replaced by the entered mail.
 LDAP_USER_FILTER: '(&(memberof=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)(uid=%u))'
 
 # If user is in ADMIN_GROUP on user creation (first login) isAdmin is set to true. 
 # Admin Users can invite external (non ldap) users. This feature makes only sense 
 # when ALLOW_EMAIL_LOGIN is set to 'true'. Additionally admins can send 
 # system wide messages.
+# All occurrences of `%u` get replaced by the entered uid.
+# All occurrences of `%m`get replaced by the entered mail.
 #LDAP_ADMIN_GROUP_FILTER: '(memberof=cn=ADMINGROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)'
 ALLOW_EMAIL_LOGIN: 'false'
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ LDAP_BIND_USER: cn=ldap_reader,dc=DOMAIN,dc=TLS
 LDAP_BIND_PW: TopSecret
 # users need to match this filter to login.
 #All occurrences of `%u` get replaced by the entered uid.
-LDAP_USER_FILTER: '(memberof=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)(uid=%u)'
+LDAP_USER_FILTER: '(&(memberof=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)(uid=%u))'
 
 # If user is in ADMIN_GROUP on user creation (first login) isAdmin is set to true. 
 # Admin Users can invite external (non ldap) users. This feature makes only sense 
@@ -103,6 +103,7 @@ function `getLdapContacts()` in ContactsController.js (line 92)
 if you want to enable this function set:
 ```
 LDAP_CONTACTS: 'true'
+LDAP_GROUP_FILTER: '(memberof=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)'
 ```
 
 ### Sharelatex Configuration

--- a/docker-compose.certbot.yml
+++ b/docker-compose.certbot.yml
@@ -58,8 +58,8 @@ services:
             LDAP_SERVER: ldaps://LDAPSERVER:636
             LDAP_BASE: ou=people,dc=DOMAIN,dc=TLD
             LDAP_BINDDN: ou=someunit,ou=people,dc=DOMAIN,dc=TLS
-            # By default tries to bind directly with the ldap user - this user has to be in the LDAP GROUP
-            LDAP_GROUP_FILTER: '(memberof=cn=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)'
+            # Binds with the LDAP_BIND_USER and searches for users matching this filter:
+            LDAP_USER_FILTER: '(memberof=cn=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)(uid=%u)'
 
             # If user is in ADMIN_GROUP on user creation (first login) isAdmin is set to true. 
             # Admin Users can invite external (non ldap) users. This feature makes only sense 
@@ -71,6 +71,7 @@ services:
             # All users in the LDAP_GROUP_FILTER are loaded from the ldap server into contacts.
             # This LDAP search happens without bind. If you want this and your LDAP needs a bind you can 
             # adapt this in the function getLdapContacts() in ContactsController.js (lines 82 - 107)
+            LDAP_GROUP_FILTER: '(memberof=cn=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)'
             LDAP_CONTACTS: 'false'
 
             # Same property, unfortunately with different names in

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -135,15 +135,14 @@ services:
             
             LDAP_SERVER: ldaps://LDAPSERVER:636
             LDAP_BASE: ou=people,dc=DOMAIN,dc=TLD
-            LDAP_BINDDN: ou=someunit,ou=people,dc=DOMAIN,dc=TLS
-            
-            # By default tries to bind directly with the ldap user - this user has to be in the LDAP GROUP
-            # LDAP_GROUP_FILTER: '(memberof=cn=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)'
-            LDAP_GROUP_FILTER: '(memberof=cn=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)'
+            #LDAP_BINDDN: ou=someunit,ou=people,dc=DOMAIN,dc=TLS
 
-            # If user is in ADMIN_GROUP on user creation (first login) isAdmin is set to true. 
-            # Admin Users can invite external (non ldap) users. This feature makes only sense 
-            # when ALLOW_EMAIL_LOGIN is set to 'true'. Additionally admins can send 
+            # # Binds with the LDAP_BIND_USER and searches for users matching this filter:
+            LDAP_USER_FILTER: '(memberof=cn=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)(uid=%u)'
+
+            # If user is in ADMIN_GROUP on user creation (first login) isAdmin is set to true.
+            # Admin Users can invite external (non ldap) users. This feature makes only sense
+            # when ALLOW_EMAIL_LOGIN is set to 'true'. Additionally admins can send
             # system wide messages.
             LDAP_ADMIN_GROUP_FILTER: '(memberof=cn=ADMINGROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)'
             ALLOW_EMAIL_LOGIN: 'true'
@@ -151,6 +150,7 @@ services:
             # All users in the LDAP_GROUP_FILTER are loaded from the ldap server into contacts.
             # This LDAP search happens without bind. If you want this and your LDAP needs a bind you can 
             # adapt this in the function getLdapContacts() in ContactsController.js (lines 82 - 107)
+            LDAP_GROUP_FILTER: '(memberof=cn=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)'
             LDAP_CONTACTS: 'false'
 
             # Same property, unfortunately with different names in

--- a/ldap-overleaf-sl/Dockerfile
+++ b/ldap-overleaf-sl/Dockerfile
@@ -18,6 +18,7 @@ RUN npm install -g npm
 #RUN npm cache clean --force
 RUN npm install ldapts-search
 RUN npm install ldapts
+RUN npm install ldap-escape
 #RUN npm install bcrypt@5.0.0
 
 # This variant of updateing texlive does not work

--- a/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
+++ b/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
@@ -274,11 +274,11 @@ const AuthenticationManager = {
     const ldap_reader_pass = process.env.LDAP_BIND_PW
     const ldap_base = process.env.LDAP_BASE
     var mail = query.email
-    const filterstr = '(&' + process.env.LDAP_GROUP_FILTER + '(mail=' + mail + '))'
+    const uid = query.email.split('@')[0]
+    const filterstr = '(&' + process.env.LDAP_GROUP_FILTER + '(uid=' + uid + '))'
     var userDn = "" //'uid=' + uid + ',' + ldap_bd;
     var firstname = ""
     var lastname = ""
-    var uid = ""
     var isAdmin = false
     // check bind
     try {

--- a/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
+++ b/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
@@ -325,7 +325,7 @@ const AuthenticationManager = {
         });
         await adminEntry;
         //console.log("Admin Search response:" + JSON.stringify(adminEntry.searchEntries))
-        if (adminEntry.searchEntries[0].mail) {
+        if (adminEntry.searchEntries[0]) {
           console.log("is Admin")
           isAdmin=true;
         }

--- a/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
+++ b/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
@@ -275,8 +275,7 @@ const AuthenticationManager = {
     const ldap_reader_pass = process.env.LDAP_BIND_PW
     const ldap_base = process.env.LDAP_BASE
     var uid = query.email
-    const searchTerm = "%u"
-    const replacer = new RegExp(searchTerm, "g")
+    const replacer = new RegExp("%u", "g")
     const filterstr = process.env.LDAP_GROUP_FILTER.replace(replacer, ldapEscape.filter`${uid}`) //replace all appearances
     console.log("filterstr:" + filterstr)
     var userDn = "" //ldapEscape.filter`uid=${uid}` + ',' + ldap_bd;

--- a/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
+++ b/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
@@ -275,8 +275,11 @@ const AuthenticationManager = {
     const ldap_reader_pass = process.env.LDAP_BIND_PW
     const ldap_base = process.env.LDAP_BASE
     var uid = query.email
-    const filterstr = process.env.LDAP_GROUP_FILTER.replaceAll('%u', ldapEscape.filter`${uid}`)
-    const userDn = ldapEscape.filter`uid=${uid}` + ',' + ldap_bd;
+    const searchTerm = "%u"
+    const replacer = new RegExp(searchTerm, "g")
+    const filterstr = process.env.LDAP_GROUP_FILTER.replace(replacer, ldapEscape.filter`${uid}`) //replace all appearances
+    console.log("filterstr:" + filterstr)
+    var userDn = "" //ldapEscape.filter`uid=${uid}` + ',' + ldap_bd;
     var mail = ""
     var firstname = ""
     var lastname = ""
@@ -315,7 +318,7 @@ const AuthenticationManager = {
       // if admin filter is set - only set admin for user in ldap group
       // does not matter - admin is deactivated: managed through ldap
       if (process.env.LDAP_ADMIN_GROUP_FILTER) {
-        const adminfilter = process.env.LDAP_ADMIN_GROUP_FILTER.replaceAll('%u', ldapEscape.filter`${uid}`)
+        const adminfilter = process.env.LDAP_ADMIN_GROUP_FILTER.replace(replacer, ldapEscape.filter`${uid}`)
         adminEntry = await client.search(ldap_base, {
           scope: 'sub',
           filter: adminfilter,

--- a/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
+++ b/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
@@ -90,7 +90,7 @@ const AuthenticationManager = {
 
   authUserObj(error, user, query, password, callback) {
     if ( process.env.ALLOW_EMAIL_LOGIN && user && user.hashedPassword) {
-        console.log("email login for existing user " + query.mail)
+        console.log("email login for existing user " + query.email)
         // check passwd against local db
         bcrypt.compare(password, user.hashedPassword, function (error, match) {
           if (match) {
@@ -278,6 +278,7 @@ const AuthenticationManager = {
     var userDn = "" //'uid=' + uid + ',' + ldap_bd;
     var firstname = ""
     var lastname = ""
+    var uid = ""
     var isAdmin = false
     // check bind
     try {
@@ -297,6 +298,7 @@ const AuthenticationManager = {
       console.log(JSON.stringify(searchEntries))
       if (searchEntries[0]) {
         mail = searchEntries[0].mail
+        uid = searchEntries[0].uid
         firstname = searchEntries[0].givenName
         lastname = searchEntries[0].sn
         userDn = searchEntries[0].dn

--- a/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
+++ b/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
@@ -276,7 +276,7 @@ const AuthenticationManager = {
     const ldap_base = process.env.LDAP_BASE
     var uid = query.email
     const replacer = new RegExp("%u", "g")
-    const filterstr = process.env.LDAP_GROUP_FILTER.replace(replacer, ldapEscape.filter`${uid}`) //replace all appearances
+    const filterstr = process.env.LDAP_USER_FILTER.replace(replacer, ldapEscape.filter`${uid}`) //replace all appearances
     console.log("filterstr:" + filterstr)
     var userDn = "" //ldapEscape.filter`uid=${uid}` + ',' + ldap_bd;
     var mail = ""

--- a/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
+++ b/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
@@ -275,10 +275,10 @@ const AuthenticationManager = {
     //const bindPassword = process.env.LDAP_BIND_PW
     const ldap_bd = process.env.LDAP_BINDDN
     const ldap_base = process.env.LDAP_BASE
-    var mail = query.email 
-    var uid = query.email.split('@')[0]
-    const filterstr = '(&' + process.env.LDAP_GROUP_FILTER + '(' + ldapEscape.filter`uid=${uid}` + '))'
+    var uid = query.email
+    const filterstr = process.env.LDAP_GROUP_FILTER.replaceAll('%u', ldapEscape.filter`${uid}`)
     const userDn = ldapEscape.filter`uid=${uid}` + ',' + ldap_bd;
+    var mail = ""
     var firstname = ""
     var lastname = ""
     var isAdmin = false
@@ -313,7 +313,7 @@ const AuthenticationManager = {
       // if admin filter is set - only set admin for user in ldap group
       // does not matter - admin is deactivated: managed through ldap
       if (process.env.LDAP_ADMIN_GROUP_FILTER) {
-        const adminfilter = '(&' + process.env.LDAP_ADMIN_GROUP_FILTER + '(' +ldapEscape.filter`uid=${uid}` + '))' 
+        const adminfilter = process.env.LDAP_ADMIN_GROUP_FILTER.replaceAll('%u', ldapEscape.filter`${uid}`)
         adminEntry = await client.search(ldap_base, {
           scope: 'sub',
           filter: adminfilter,

--- a/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
+++ b/ldap-overleaf-sl/sharelatex/AuthenticationManager.js
@@ -274,7 +274,7 @@ const AuthenticationManager = {
     const ldap_reader_pass = process.env.LDAP_BIND_PW
     const ldap_base = process.env.LDAP_BASE
     var mail = query.email
-    const uid = query.email.split('@')[0]
+    var uid = query.email.split('@')[0]
     const filterstr = '(&' + process.env.LDAP_GROUP_FILTER + '(uid=' + uid + '))'
     var userDn = "" //'uid=' + uid + ',' + ldap_bd;
     var firstname = ""


### PR DESCRIPTION
Based on the great work of @chhu in #6 this allows the use of a dedicated bind user. We took a less restricting approach for the format of the used filter strings.