### PR TITLE
Fix import of contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ If you upgrade from an older commit:
 **Note**: 
  - you have to add: uid=%u to your BIND_DN 
  - LDAP_GROUP_FILTER is now named LDAP_USER_FILTER
+ - Import of contacts from LDAP is now controlled by LDAP_CONTACT_FILTER
 
 
 Only valid LDAP users or email users registered by an admin can login. 
@@ -103,16 +104,18 @@ LDAP_USER_FILTER: '(&(memberof=GROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)(uid=%u))'
 #LDAP_ADMIN_GROUP_FILTER: '(memberof=cn=ADMINGROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)'
 ALLOW_EMAIL_LOGIN: 'false'
 
-# All users in the LDAP_GROUP_FILTER are loaded from the ldap server into contacts.
+# All users in the LDAP_CONTACT_FILTER are loaded from the ldap server into contacts.
+LDAP_CONTACT_FILTER: (objectClass=person)
 LDAP_CONTACTS: 'false'
 ```
 
 ### LDAP Contacts 
 
-If you enable LDAP_CONTACTS, then all users in LDAP_USER_FILTER are loaded from the ldap server into the contacts. 
+If you enable LDAP_CONTACTS, then all users in LDAP_CONTACT_FILTER are loaded from the ldap server into the contacts.
 At the moment this happens every time you click on "Share" within a project.
 if you want to enable this function set:
 ```
+LDAP_CONTACT_FILTER: (objectClass=person)
 LDAP_CONTACTS: 'true'
 ```
 

--- a/docker-compose.certbot.yml
+++ b/docker-compose.certbot.yml
@@ -77,7 +77,7 @@ services:
             LDAP_ADMIN_GROUP_FILTER: '(memberof=cn=ADMINGROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)'
             ALLOW_EMAIL_LOGIN: 'true'
 
-            # All users in the LDAP_USER_FILTER are loaded from the ldap server into contacts.
+            # All users in the LDAP_CONTACT_FILTER are loaded from the ldap server into contacts.
             LDAP_CONTACTS: 'false'
 
             # Same property, unfortunately with different names in

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -156,7 +156,7 @@ services:
             LDAP_ADMIN_GROUP_FILTER: '(memberof=cn=ADMINGROUPNAME,ou=groups,dc=DOMAIN,dc=TLD)'
             ALLOW_EMAIL_LOGIN: 'true'
 
-            # All users in the LDAP_USER_FILTER are loaded from the ldap server into contacts.
+            # All users in the LDAP_CONTACT_FILTER are loaded from the ldap server into contacts.
             LDAP_CONTACTS: 'false'
 
             # Same property, unfortunately with different names in

--- a/ldap-overleaf-sl/sharelatex/ContactController.js
+++ b/ldap-overleaf-sl/sharelatex/ContactController.js
@@ -100,7 +100,7 @@ module.exports = ContactsController = {
     // get user data
     try {
       // if you need an client.bind do it here.
-      const {searchEntries,searchReferences,} = await client.search(ldap_base, {scope: 'sub',filter: process.env.LDAP_USER_FILTER ,});
+      const {searchEntries,searchReferences,} = await client.search(ldap_base, {scope: 'sub',filter: process.env.LDAP_CONTACT_FILTER ,});
       await searchEntries;
       for (var i = 0; i < searchEntries.length; i++) {
        var entry = new Map()


### PR DESCRIPTION
Since the `LDAP_USER_FILTER` needs to contain the bit `uid=%u` in case one uses a seperate bind user, to verify the entered username, the `LDAP_USER_FILTER` can't be used as the filter to import contacts. Instead I propose to use a seperate `LDAP_CONTACT_FILTER`.