### PR TITLE
Fix parsing the LDAP_CONTACTS environment variable

### DIFF
--- a/ldap-overleaf-sl/sharelatex/ContactController.js
+++ b/ldap-overleaf-sl/sharelatex/ContactController.js
@@ -80,7 +80,7 @@ module.exports = ContactsController = {
     })
   },
   async getLdapContacts(contacts) {
-    if (! process.env.LDAP_CONTACTS) {
+    if (process.env.LDAP_CONTACTS === undefined || !(process.env.LDAP_CONTACTS.toLowerCase() === 'true')) {
        return contacts
     }
     const client = new Client({


### PR DESCRIPTION
The current code skips loading contact information from LDAP if
`!process.env.LDAP_CONTACTS` evaluates to `true`.

This is nearly never the case, as `process.env` contains strings
and non-empty strings evaluate to `true`, making the negation falsy.
Only an empty string in `LDAP_CONTACTS` (or not setting the environment
variable at all) skips the contact loading.

This PR changes the logic to only load contacts from LDAP if the
`LDAP_CONTACTS` environment variable is explicitly set to `"true"` (case
insensitive). This should bring the behaviour of the application more in
line with the expectation and the docs.