### PR TITLE
Pin the ldapts package version, change the path of the fronted files to follow the changes of Overleaf-CE 3.1

### DIFF
--- a/ldap-overleaf-sl/Dockerfile
+++ b/ldap-overleaf-sl/Dockerfile
@@ -11,7 +11,7 @@ ARG login_text
 ARG admin_is_sysadmin
 
 # set workdir (might solve issue #2 - see https://stackoverflow.com/questions/57534295/)
-WORKDIR /var/www/sharelatex/web
+WORKDIR /overleaf/services/web
 
 # install latest npm
 RUN npm install -g npm
@@ -19,7 +19,7 @@ RUN npm install -g npm
 #RUN npm cache clean --force
 RUN npm install ldap-escape
 RUN npm install ldapts-search
-RUN npm install ldapts
+RUN npm install ldapts@3.2.4
 RUN npm install ldap-escape
 #RUN npm install bcrypt@5.0.0
 
@@ -31,38 +31,38 @@ RUN apt-get -y install python-pygments
 #RUN apt-get -y install texlive texlive-lang-german texlive-latex-extra texlive-full texlive-science
 
 # overwrite some files
-COPY sharelatex/AuthenticationManager.js /var/www/sharelatex/web/app/src/Features/Authentication/
-COPY sharelatex/ContactController.js 	/var/www/sharelatex/web/app/src/Features/Contacts/
+COPY sharelatex/AuthenticationManager.js /overleaf/services/web/app/src/Features/Authentication/
+COPY sharelatex/ContactController.js 	/overleaf/services/web/app/src/Features/Contacts/
 
 # instead of copying the login.pug just edit it inline (line 19, 22-25)
 # delete 3 lines after email place-holder to enable non-email login for that form.
-RUN sed -iE '/type=.*email.*/d' /var/www/sharelatex/web/app/views/user/login.pug
-RUN sed -iE '/email@example.com/{n;N;N;d}' /var/www/sharelatex/web/app/views/user/login.pug
-RUN sed -iE "s/email@example.com/${login_text:-user}/g" /var/www/sharelatex/web/app/views/user/login.pug
+RUN sed -iE '/type=.*email.*/d' /overleaf/services/web/app/views/user/login.pug
+# RUN sed -iE '/email@example.com/{n;N;N;d}' /overleaf/services/web/app/views/user/login.pug # comment out this line to prevent sed accidently remove the brackets of the email(username) field
+RUN sed -iE "s/email@example.com/${login_text:-user}/g" /overleaf/services/web/app/views/user/login.pug
 
 # Collaboration settings display (share project placeholder) | edit line 146
 # share.pug file was removed in later versions
-# RUN sed -iE "s%placeholder=.*$%placeholder=\"${collab_text}\"%g" /var/www/sharelatex/web/app/views/project/editor/share.pug
+# RUN sed -iE "s%placeholder=.*$%placeholder=\"${collab_text}\"%g" /overleaf/services/web/app/views/project/editor/share.pug
 
 # extend pdflatex with option shell-esacpe ( fix for closed overleaf/overleaf/issues/217 and overleaf/docker-image/issues/45 )
 # do this in different ways for different sharelatex versions
-RUN sed -iE "s%-synctex=1\",%-synctex=1\", \"-shell-escape\",%g" /var/www/sharelatex/clsi/app/js/LatexRunner.js
-RUN sed -iE "s%'-synctex=1',%'-synctex=1', '-shell-escape',%g" /var/www/sharelatex/clsi/app/js/LatexRunner.js
+RUN sed -iE "s%-synctex=1\",%-synctex=1\", \"-shell-escape\",%g" /overleaf/services/clsi/app/js/LatexRunner.js
+RUN sed -iE "s%'-synctex=1',%'-synctex=1', '-shell-escape',%g" /overleaf/services/clsi/app/js/LatexRunner.js
 
 # Too much changes to do inline (>10 Lines).
-COPY sharelatex/settings.pug 		/var/www/sharelatex/web/app/views/user/
-COPY sharelatex/navbar.pug 		/var/www/sharelatex/web/app/views/layout/
+COPY sharelatex/settings.pug 		/overleaf/services/web/app/views/user/
+COPY sharelatex/navbar.pug 		/overleaf/services/web/app/views/layout/
 
 # Non LDAP User Registration for Admins
-COPY sharelatex/admin-index.pug 	/var/www/sharelatex/web/app/views/admin/index.pug
+COPY sharelatex/admin-index.pug 	/overleaf/services/web/app/views/admin/index.pug
 COPY sharelatex/admin-sysadmin.pug 	/tmp/admin-sysadmin.pug
-RUN if [ "${admin_is_sysadmin}" = "true" ] ; then cp /tmp/admin-sysadmin.pug   /var/www/sharelatex/web/app/views/admin/index.pug ; else rm /tmp/admin-sysadmin.pug ; fi
+RUN if [ "${admin_is_sysadmin}" = "true" ] ; then cp /tmp/admin-sysadmin.pug   /overleaf/services/web/app/views/admin/index.pug ; else rm /tmp/admin-sysadmin.pug ; fi
 
-RUN rm /var/www/sharelatex/web/app/views/admin/register.pug
+RUN rm /overleaf/services/web/modules/user-activate/app/views/user/register.pug
 
 ### To remove comments entirly (bug https://github.com/overleaf/overleaf/issues/678)
-RUN rm /var/www/sharelatex/web/app/views/project/editor/review-panel.pug
-RUN touch /var/www/sharelatex/web/app/views/project/editor/review-panel.pug
+RUN rm /overleaf/services/web/app/views/project/editor/review-panel.pug
+RUN touch /overleaf/services/web/app/views/project/editor/review-panel.pug
 
 ### Nginx and Certificates
 # enable https via letsencrypt


### PR DESCRIPTION
…in overleaf docker image.

Pin the version of the ldapts package to 3.2.4 as ldapts 4.0.0 drops the nodejs 12 support.
Change the path of the fronted files in overleaf docker image to follow the changes in overleaf 3.1