### PR TITLE
Added check for active OAuth to login route

### DIFF
--- a/ldap-overleaf-sl/sharelatex_diff/router.js.diff
+++ b/ldap-overleaf-sl/sharelatex_diff/router.js.diff
@@ -1,4 +1,16 @@
-259a260,268
+217c217,225
+<   webRouter.get('/login', UserPagesController.loginPage)
+---
+>   // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+>   if (process.env.OAUTH2_ENABLED === 'true') {
+>     webRouter.get('/login', function (req, res, next) {
+>       res.redirect('/oauth/redirect')
+>     })
+>   } else {
+>     webRouter.get('/login', UserPagesController.loginPage)
+>   }
+>   // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+259a268,276
 >   // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 >   if (process.env.OAUTH2_ENABLED === 'true') {
 >     webRouter.get('/oauth/redirect', AuthenticationController.oauth2Redirect)

--- a/ldap-overleaf-sl/sharelatex_diff/router.js.diff
+++ b/ldap-overleaf-sl/sharelatex_diff/router.js.diff
@@ -10,7 +10,7 @@
 >     webRouter.get('/login', UserPagesController.loginPage)
 >   }
 >   // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-259a268,276
+259a268,275
 >   // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 >   if (process.env.OAUTH2_ENABLED === 'true') {
 >     webRouter.get('/oauth/redirect', AuthenticationController.oauth2Redirect)
@@ -19,4 +19,4 @@
 >     AuthenticationController.addEndpointToLoginWhitelist('/oauth/callback')
 >   }
 >   // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-> 
+


### PR DESCRIPTION
This adds a way to directly skip the login page when OAuth is enabled. 

If needed, there could be a variable to enable this, although I don't see the value since adding the OAuth provider broke the regular login for me anyway.

Fixes #42 .