### PR TITLE
Make the oauth2 state length configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ OAUTH2_TOKEN_URL: YOUR_OAUTH2_TOKEN_URL
 # One of ["application/x-www-form-urlencoded", "application/json"]
 # Default "application/x-www-form-urlencoded"
 OAUTH2_TOKEN_CONTENT_TYPE: "application/x-www-form-urlencoded"
+# OAUTH2_STATE_LENGTH: Length of the OAuth2 state
+OAUTH2_STATE_LENGTH: 6
 # Fetch user profile api endpoint
 OAUTH2_PROFILE_URL: YOUR_OAUTH2_PROFILE_URL
 

--- a/docker-compose.certbot.yml
+++ b/docker-compose.certbot.yml
@@ -91,6 +91,7 @@ services:
       # OAUTH2_AUTHORIZATION_URL: YOUR_OAUTH2_AUTHORIZATION_URL
       # OAUTH2_TOKEN_URL: YOUR_OAUTH2_TOKEN_URL
       # OAUTH2_TOKEN_CONTENT_TYPE: # One of ['application/x-www-form-urlencoded', 'application/json']
+      # OAUTH2_STATE_LENGTH: Length of the OAuth2 state (default: 6)
       # OAUTH2_PROFILE_URL: YOUR_OAUTH2_PROFILE_URL
       # OAUTH2_USER_ATTR_EMAIL: email
       # OAUTH2_USER_ATTR_UID: id

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -172,6 +172,7 @@ services:
       # OAUTH2_AUTHORIZATION_URL: YOUR_OAUTH2_AUTHORIZATION_URL
       # OAUTH2_TOKEN_URL: YOUR_OAUTH2_TOKEN_URL
       # OAUTH2_TOKEN_CONTENT_TYPE: # One of ['application/x-www-form-urlencoded', 'application/json']
+      # OAUTH2_STATE_LENGTH: Length of the OAuth2 state (default: 6)
       # OAUTH2_PROFILE_URL: YOUR_OAUTH2_PROFILE_URL
       # OAUTH2_USER_ATTR_EMAIL: email
       # OAUTH2_USER_ATTR_UID: id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
       # OAUTH2_AUTHORIZATION_URL: YOUR_OAUTH2_AUTHORIZATION_URL
       # OAUTH2_TOKEN_URL: YOUR_OAUTH2_TOKEN_URL
       # OAUTH2_TOKEN_CONTENT_TYPE: # One of ['application/x-www-form-urlencoded', 'application/json']
+      # OAUTH2_STATE_LENGTH: Length of the OAuth2 state (default: 6)
       # OAUTH2_PROFILE_URL: YOUR_OAUTH2_PROFILE_URL
       # OAUTH2_USER_ATTR_EMAIL: email
       # OAUTH2_USER_ATTR_UID: id

--- a/ldap-overleaf-sl/sharelatex_diff/AuthenticationController.js.diff
+++ b/ldap-overleaf-sl/sharelatex_diff/AuthenticationController.js.diff
@@ -4,7 +4,7 @@
 >   oauth2Redirect(req, res, next) {
 >     // random state
 >     const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
->     const state = new Array(6).fill(0).map(() => characters.charAt(Math.floor(Math.random() * characters.length))).join("")
+>     const state = new Array(8).fill(0).map(() => characters.charAt(Math.floor(Math.random() * characters.length))).join("")
 >     req.session.oauth2State = state
 > 
 >     const redirectURI = encodeURIComponent(`${process.env.SHARELATEX_SITE_URL}/oauth/callback`) 

--- a/ldap-overleaf-sl/sharelatex_diff/AuthenticationController.js.diff
+++ b/ldap-overleaf-sl/sharelatex_diff/AuthenticationController.js.diff
@@ -1,10 +1,11 @@
-268a268,364
+268a269,366
 > 
 > // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 >   oauth2Redirect(req, res, next) {
 >     // random state
 >     const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
->     const state = new Array(8).fill(0).map(() => characters.charAt(Math.floor(Math.random() * characters.length))).join("")
+>     const stateLength = Number(process.env.OAUTH2_STATE_LENGTH || 6)
+>     const state = new Array(stateLength).fill(0).map(() => characters.charAt(Math.floor(Math.random() * characters.length))).join("")
 >     req.session.oauth2State = state
 > 
 >     const redirectURI = encodeURIComponent(`${process.env.SHARELATEX_SITE_URL}/oauth/callback`) 


### PR DESCRIPTION
Authelia requires that the state must be at least be 8 characters long to ensure sufficient entropy